### PR TITLE
Add status and index fields to staking contract

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,6 +39,15 @@ The API provides endpoints for interacting with the TinyChain node. It allows us
    - Validators sign the block and broadcast their signatures to the network.
    - Once a block receives signatures from a majority of validators, it is considered valid and added to the blockchain.
 
+## Staking Contract
+
+The staking contract in TinyChain includes the following fields for each validator:
+
+- **Public Key**: The public key of the validator.
+- **Staked Balance**: The amount of tokens staked by the validator.
+- **Status**: The status of the validator (e.g., active, inactive).
+- **Index**: The index value of the validator, which is determined by the order in which they joined the validator set. Validators with identical stakes are typically ordered deterministically, with those who joined earlier having a lower index.
+
 ## High-Level Diagram
 
 Below is a high-level diagram of the TinyChain architecture:

--- a/src/vm.py
+++ b/src/vm.py
@@ -98,17 +98,17 @@ class TinyVMEngine:
     def execute_staking_contract(self, contract_state, sender, amount, operation, accounts_contract_state):
         if contract_state is None:
             contract_state = {}
-        staked_balance = contract_state.get(sender, 0)
+        staked_balance = contract_state.get(sender, {"balance": 0, "status": "active", "index": len(contract_state)})
         if operation:
-            new_staked_balance = staked_balance + amount
-            contract_state[sender] = new_staked_balance
+            new_staked_balance = staked_balance["balance"] + amount
+            contract_state[sender] = {"balance": new_staked_balance, "status": "active", "index": staked_balance["index"]}
             logging.info(
                 f"TinyVM (staking contract): {sender} staked {amount} tinycoins for contract {self.staking_contract_address}. New staked balance: {new_staked_balance}"
             )
         else:
-            if staked_balance > 0:
-                released_balance = staked_balance
-                contract_state[sender] = 0
+            if staked_balance["balance"] > 0:
+                released_balance = staked_balance["balance"]
+                contract_state[sender] = {"balance": 0, "status": "inactive", "index": staked_balance["index"]}
                 self.execute_accounts_contract(
                     accounts_contract_state,
                     self.staking_contract_address,


### PR DESCRIPTION
Add `status` and `index` fields to the staking contract state and update related methods.

* **`src/vm.py`**
  - Modify `execute_staking_contract` method to include `status` and `index` fields in the staking contract state.
  - Update the method to handle staking and unstaking operations, setting the `status` to "active" or "inactive" based on the staked balance.
  - Ensure the `index` value is assigned based on the order in which validators join the validator set.

* **`docs/architecture.md`**
  - Update the documentation to include `status` and `index` fields in the staking contract description.
  - Explain the purpose and determination of the `index` value for validators.

