### PR TITLE
Store block in memory until 2/3 validators sign

### DIFF
--- a/src/block.py
+++ b/src/block.py
@@ -42,6 +42,9 @@ class BlockHeader:
             header_data['transaction_hashes']
         )
 
+    def append_signature(self, validator_address, signature):
+        self.signatures.append({"validator_address": validator_address, "signature": signature})
+
 class Block:
     def __init__(self, header, transactions):
         self.header = header

--- a/src/validation_engine.py
+++ b/src/validation_engine.py
@@ -138,3 +138,24 @@ class ValidationEngine:
                 return False
 
         return True
+
+    def validate_collected_signatures(self, block_header, required_signatures):
+        """
+        Validate the collected signatures from validators.
+        
+        Args:
+            block_header (BlockHeader): The block header containing the signatures.
+            required_signatures (int): The number of required signatures for validation.
+        
+        Returns:
+            bool: True if the required number of valid signatures is collected, False otherwise.
+        """
+        valid_signatures = 0
+        for signature in block_header.signatures:
+            validator_address = signature["validator_address"]
+            signature_value = signature["signature"]
+            if Wallet.verify_signature(block_header.block_hash, signature_value, validator_address):
+                valid_signatures += 1
+            if valid_signatures >= required_signatures:
+                return True
+        return False


### PR DESCRIPTION
Modify the `forge_new_block` method to store the block header in memory until 2/3 validators sign.

* **In-Memory Storage:**
  - Add `self.in_memory_blocks` and `self.in_memory_block_headers` to store blocks and block headers temporarily in memory.

* **Block Header Broadcasting:**
  - Add `broadcast_block_header` method to broadcast block header to validators.
  - Add `has_enough_signatures` method to check if 2/3 validators have signed.

* **Validation Engine:**
  - Add `validate_collected_signatures` method to validate the collected signatures from validators.

* **Block Header Signature:**
  - Add `append_signature` method to `BlockHeader` class to append signatures to the block header.

