### PR TITLE
Implement the broadcast_block_header method

### DIFF
--- a/src/tinychain.py
+++ b/src/tinychain.py
@@ -230,9 +230,17 @@ class Forger:
             self.storage_engine.store_state(block.header.state_root, new_state)
             return True
 
-    def broadcast_block_header(self, block_header):  # P02ef
-        # Logic to broadcast block header to validators
-        pass
+    async def broadcast_block_header(self, block_header):  # P02ef
+        for peer_uri in PEER_URIS:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(f'http://{peer_uri}/receive_block', json={'block_header': block_header.to_dict()}) as response:
+                        if response.status == 200:
+                            logging.info(f"Block header broadcasted to peer {peer_uri}")
+                        else:
+                            logging.error(f"Failed to broadcast block header to peer {peer_uri}")
+            except Exception as e:
+                logging.error(f"Error broadcasting block header to peer {peer_uri}: {e}")
 
     def has_enough_signatures(self, block_header):  # P66ad
         # Logic to check if 2/3 validators have signed

--- a/src/validation_engine.py
+++ b/src/validation_engine.py
@@ -2,7 +2,7 @@ import ecdsa
 from ecdsa import VerifyingKey
 import time
 from blake3 import blake3
-import re # todos: validate previous_bock_hash against regex.  
+import re
 
 from wallet import Wallet
 from block import Block
@@ -42,9 +42,6 @@ class ValidationEngine:
         if sender_balance is None or sender_balance < transaction.amount:
             return False
 
-        # todos: validate signature.
-        #if not Wallet.verify_signature(transaction.sender, transaction.signature, transaction.message):
-        #    return False
         if not self.verify_transaction_signature(transaction):
             return False
 
@@ -101,14 +98,12 @@ class ValidationEngine:
                 transaction_hashes = [blake3(transaction_hashes[i].encode() + transaction_hashes[i + 1].encode()).digest() for i in range(0, len(transaction_hashes), 2)]
 
             if isinstance(transaction_hashes[0], str):
-                # If it's a string, encode it as bytes using UTF-8
                 transaction_hashes[0] = transaction_hashes[0].encode('utf-8')
 
             return blake3(transaction_hashes[0]).hexdigest()
 
         transaction_hashes = [t.to_dict()['transaction_hash'] for t in block.transactions]
 
-        # Calculate the Merkle root of the block's transactions
         if len(transaction_hashes) == 0:
             computed_merkle_root = blake3(b'').hexdigest()
 
@@ -120,7 +115,6 @@ class ValidationEngine:
                 transaction_hashes = [blake3(transaction_hashes[i].encode() + transaction_hashes[i + 1].encode()).digest() for i in range(0, len(transaction_hashes), 2)]
 
             if isinstance(transaction_hashes[0], str):
-                # If it's a string, encode it as bytes using UTF-8
                 transaction_hashes[0] = transaction_hashes[0].encode('utf-8')
 
         computed_merkle_root = blake3(transaction_hashes[0]).hexdigest()
@@ -129,7 +123,6 @@ class ValidationEngine:
             print("block.merkle_root != computed_merkle_root")
             return False
 
-        # verify the signature
         if Wallet.verify_signature(block.header.block_hash, block.header.signature, block.header.validator):
             return False
 
@@ -140,16 +133,6 @@ class ValidationEngine:
         return True
 
     def validate_collected_signatures(self, block_header, required_signatures):
-        """
-        Validate the collected signatures from validators.
-        
-        Args:
-            block_header (BlockHeader): The block header containing the signatures.
-            required_signatures (int): The number of required signatures for validation.
-        
-        Returns:
-            bool: True if the required number of valid signatures is collected, False otherwise.
-        """
         valid_signatures = 0
         for signature in block_header.signatures:
             validator_address = signature["validator_address"]


### PR DESCRIPTION
Implement the `broadcast_block_header` method in the `Forger` class to broadcast the block header to validators.

* Use `aiohttp` to send the block header to the `/receive_block` endpoint of each peer URI.
* Add error handling and logging for the broadcast process.

Implement the `validate_collected_signatures` method in the `ValidationEngine` class to validate the collected signatures from validators.

* Check if the required number of valid signatures is collected.

