### PR TITLE
Add logic to find proposer signature in block header

### DIFF
--- a/src/block.py
+++ b/src/block.py
@@ -92,6 +92,12 @@ class BlockHeader:
         signature = Signature(validator_address, timestamp, signature_data)
         self.signatures.append(signature)
 
+    def find_signature_by_validator(self, validator_address):
+        for signature in self.signatures:
+            if signature.validator_address == validator_address:
+                return signature
+        return None
+
 class Block:
     def __init__(self, header, transactions):
         self.header = header


### PR DESCRIPTION
Add logic to iterate through `block_header.signatures` to find the signature that matches the proposer address `block_header.proposer`.

* Add a helper function `find_proposer_signature` in `src/tinychain.py` to encapsulate the logic for finding the proposer's signature.
* Modify `receive_block_header` in `src/tinychain.py` to use `find_proposer_signature` for verifying the proposer's signature.
* Add a method `find_signature_by_validator` to the `BlockHeader` class in `src/block.py` to find a signature by validator address.

