### PR TITLE
Fix 'Signature' object is not subscriptable error

### DIFF
--- a/src/block.py
+++ b/src/block.py
@@ -35,6 +35,8 @@ class Signature:
 
     @classmethod
     def from_dict(cls, signature_data):
+        if isinstance(signature_data, Signature):
+            return signature_data
         return cls(
             signature_data['validator_address'],
             signature_data['timestamp'],

--- a/src/tinychain.py
+++ b/src/tinychain.py
@@ -179,6 +179,12 @@ class Forger:
                     signatures = block_header.signatures
                     logging.info("Block signatures: %s", signatures)
 
+                    if isinstance(signatures, list) and all(isinstance(sig, Signature) for sig in signatures):
+                        signatures.append(Signature(self.validator, int(time.time()), signature))
+                    else:
+                        signatures = [Signature.from_dict(sig) for sig in signatures]
+                        signatures.append(Signature(self.validator, int(time.time()), signature))
+
                     block_header = BlockHeader(
                         block_header.block_hash,
                         block_header.height,
@@ -187,7 +193,7 @@ class Forger:
                         block_header.merkle_root,
                         block_header.state_root,
                         block_header.proposer,
-                        signatures.append(Signature(self.validator, int(time.time()), signature)),
+                        signatures,
                         block_header.transaction_hashes
                     )
                     logging.info("Replay successful for block %s", block_header.block_hash)


### PR DESCRIPTION
Modify the `from_dict` method in the `Signature` class to handle cases where `signature_data` is a `Signature` object.

* **src/block.py**
  - Add a check in the `from_dict` method to determine if `signature_data` is a `Signature` object and return it directly if true.

* **src/tinychain.py**
  - Modify the `forge_new_block` method in the `Forger` class to handle cases where `signatures` is a list of `Signature` objects.
  - Add a check in the `forge_new_block` method to determine if `signatures` is a list of `Signature` objects and append a new `Signature` object accordingly.

