### PR TITLE
Fix MerkleTree root_hash method to handle empty leaves

### DIFF
--- a/src/merkle_tree.py
+++ b/src/merkle_tree.py
@@ -11,7 +11,7 @@ class MerkleTree:
 
     def root_hash(self):
         if len(self.leaves) == 0:
-            return None
+            return b''
 
         while len(self.leaves) > 1:
             new_leaves = []


### PR DESCRIPTION
Modify the `root_hash` method in the `MerkleTree` class to return an empty byte string instead of `None` when there are no leaves.

