### PR TITLE
Add seed phrase generator and wallet initialization

### DIFF
--- a/src/misc/seed_phrase_generator.py
+++ b/src/misc/seed_phrase_generator.py
@@ -1,0 +1,10 @@
+import mnemonic
+
+def generate_seed_phrase():
+    mnemo = mnemonic.Mnemonic("english")
+    seed_phrase = mnemo.generate(strength=256)
+    return seed_phrase
+
+if __name__ == "__main__":
+    seed_phrase = generate_seed_phrase()
+    print("Generated Seed Phrase:", seed_phrase)

--- a/src/misc/seed_phrase_generator.py
+++ b/src/misc/seed_phrase_generator.py
@@ -1,4 +1,5 @@
 import mnemonic
+from wallet import Wallet
 
 def generate_seed_phrase():
     mnemo = mnemonic.Mnemonic("english")
@@ -8,3 +9,8 @@ def generate_seed_phrase():
 if __name__ == "__main__":
     seed_phrase = generate_seed_phrase()
     print("Generated Seed Phrase:", seed_phrase)
+
+    wallet = Wallet()
+    wallet.generate_keypair_from_mnemonic(seed_phrase, "temp_wallet.dat")
+    print("Generated Keypair for Seed Phrase:")
+    print("Wallet address:", wallet.get_address())

--- a/src/tinychain.py
+++ b/src/tinychain.py
@@ -599,6 +599,9 @@ if __name__ == '__main__':
     site = web.TCPSite(app_runner, host='0.0.0.0', port=HTTP_PORT)
     loop.run_until_complete(site.start())
 
+    if not wallet.is_initialized():
+        wallet.initialize_wallet()
+
     storage_engine.open_databases()
 
     try:

--- a/src/wallet.py
+++ b/src/wallet.py
@@ -1,12 +1,27 @@
 import ecdsa
 import pickle
 import os
+import hashlib
+import hmac
+import binascii
+import mnemonic
 
 WALLET_PATH = './wallet/'
 
 class Wallet:
+    def __init__(self):
+        if not os.path.exists(os.path.join(WALLET_PATH, "wallet.dat")):
+            self.initialize_wallet()
+
     def generate_keypair(self, filename):
         private_key = ecdsa.SigningKey.generate(curve=ecdsa.SECP256k1)
+        with open(os.path.join(WALLET_PATH, filename), "wb") as file:
+            pickle.dump(private_key, file)
+        return True
+
+    def generate_keypair_from_mnemonic(self, mnemonic_seed, filename):
+        seed = mnemonic.Mnemonic.to_seed(mnemonic_seed)
+        private_key = ecdsa.SigningKey.from_string(seed[:32], curve=ecdsa.SECP256k1)
         with open(os.path.join(WALLET_PATH, filename), "wb") as file:
             pickle.dump(private_key, file)
         return True
@@ -32,6 +47,12 @@ class Wallet:
             return public_key.verify(bytes.fromhex(signature), message)
         except ecdsa.BadSignatureError:
             return False
+
+    def initialize_wallet(self):
+        mnemonic_seed = input("Enter a mnemonic seed to initialize the wallet: ")
+        self.generate_keypair_from_mnemonic(mnemonic_seed, "wallet.dat")
+        print("New wallet generated! Please fund it with some coins.")
+        print("Wallet address:", self.get_address())
 
 os.makedirs(WALLET_PATH, exist_ok=True)
 if not os.path.exists(os.path.join(WALLET_PATH, "wallet.dat")):


### PR DESCRIPTION
Add wallet initialization and mnemonic seed handling.

* **Wallet Initialization**: Add `initialize_wallet` method in `wallet.py` to prompt the user for a mnemonic seed and generate a keypair if the wallet is not initialized. Modify the `__init__` method to check if the wallet is initialized and call `initialize_wallet` if not.
* **Keypair Generation**: Add `generate_keypair_from_mnemonic` method in `wallet.py` to generate a keypair from a mnemonic seed.
* **Node Start Check**: Modify the `main` function in `tinychain.py` to check if the wallet is initialized before starting the node.
* **Seed Phrase Generator**: Add `seed_phrase_generator.py` script in the `misc` directory to generate a mnemonic seed phrase using the `mnemonic` library and print it to the console.

