### PR TITLE
Add wallet generator script and wallet initialization check

### DIFF
--- a/src/tinychain.py
+++ b/src/tinychain.py
@@ -488,6 +488,9 @@ storage_engine = StorageEngine(transactionpool)
 validation_engine = ValidationEngine(storage_engine)
 forger = Forger(transactionpool, storage_engine, validation_engine, wallet)
 
+if not wallet.is_initialized():
+    print("Wallet is not initialized. Please run wallet_generator.py to generate a wallet.")
+    exit()
 
 async def broadcast_transaction(transaction, sender_uri):
     for peer_uri in PEER_URIS:

--- a/src/wallet.py
+++ b/src/wallet.py
@@ -5,12 +5,6 @@ import os
 WALLET_PATH = './wallet/'
 
 class Wallet:
-    def generate_keypair(self, filename):
-        private_key = ecdsa.SigningKey.generate(curve=ecdsa.SECP256k1)
-        with open(os.path.join(WALLET_PATH, filename), "wb") as file:
-            pickle.dump(private_key, file)
-        return True
-
     def sign_message(self, message):
         with open(os.path.join(WALLET_PATH, "wallet.dat"), "rb") as file:
             private_key = pickle.load(file)
@@ -33,9 +27,5 @@ class Wallet:
         except ecdsa.BadSignatureError:
             return False
 
-os.makedirs(WALLET_PATH, exist_ok=True)
-if not os.path.exists(os.path.join(WALLET_PATH, "wallet.dat")):
-    wallet = Wallet()
-    wallet.generate_keypair("wallet.dat")
-    print("New wallet generated! Please fund it with some coins.")
-    print("Wallet address:", wallet.get_address())
+    def is_initialized(self):
+        return os.path.exists(os.path.join(WALLET_PATH, "wallet.dat"))

--- a/src/wallet_generator.py
+++ b/src/wallet_generator.py
@@ -1,0 +1,32 @@
+import os
+import ecdsa
+import pickle
+from mnemonic import Mnemonic
+
+WALLET_PATH = './wallet/'
+
+def generate_mnemonic():
+    mnemo = Mnemonic("english")
+    return mnemo.generate(strength=256)
+
+def generate_keypair_from_mnemonic(mnemonic):
+    seed = Mnemonic.to_seed(mnemonic)
+    private_key = ecdsa.SigningKey.from_string(seed[:32], curve=ecdsa.SECP256k1)
+    public_key = private_key.get_verifying_key()
+    return private_key, public_key
+
+def save_wallet(private_key, filename):
+    with open(os.path.join(WALLET_PATH, filename), "wb") as file:
+        pickle.dump(private_key, file)
+
+def main():
+    os.makedirs(WALLET_PATH, exist_ok=True)
+    mnemonic = generate_mnemonic()
+    private_key, public_key = generate_keypair_from_mnemonic(mnemonic)
+    save_wallet(private_key, "wallet.dat")
+    print("Mnemonic:", mnemonic)
+    print("Private Key:", private_key.to_string().hex())
+    print("Public Key:", public_key.to_string().hex())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add `wallet_generator.py` to generate mnemonic, private key, and public key, and save the private key to `wallet.dat`.

* **wallet_generator.py**
  - Import `mnemonic` library.
  - Generate mnemonic, private key, and public key.
  - Print mnemonic, private key, and public key to the screen.
  - Save the private key to `wallet.dat` file.

* **wallet.py**
  - Remove `generate_keypair` method.
  - Remove code that generates a new wallet if `wallet.dat` does not exist.
  - Add `is_initialized` method to check if `wallet.dat` exists.

* **tinychain.py**
  - Check if the wallet is initialized at the start of the script.
  - Print a message to run `wallet_generator.py` and quit if the wallet is not initialized.

