### PR TITLE
Fix unpack error in get_nonce_for_account method

### DIFF
--- a/src/tinychain.py
+++ b/src/tinychain.py
@@ -449,18 +449,19 @@ class StorageEngine:
         if accounts_state is not None:
             account_data = accounts_state.get(account_address, None)
             if account_data is not None:
-                balance, nonce = account_data
-                return nonce
-        return 0
+                balance = account_data.get("balance", 0)
+                nonce = account_data.get("nonce", 0)
+                return balance, nonce
+        return 0, 0
     
     def set_nonce_for_account(self, account_address, nonce):
         contract_address = "6163636f756e7473"
         accounts_state = self.fetch_contract_state(contract_address)
         if accounts_state is not None:
             if account_address in accounts_state:
-                accounts_state[account_address][1] = nonce
+                accounts_state[account_address]["nonce"] = nonce
             else:
-                accounts_state[account_address] = [0, nonce]
+                accounts_state[account_address] = {"balance": 0, "nonce": nonce}
             self.store_contract_state(contract_address, accounts_state)
 
     def store_contract_state(self, contract_address, state_data):

--- a/src/validation_engine.py
+++ b/src/validation_engine.py
@@ -22,7 +22,7 @@ class ValidationEngine:
         if transaction.fee <= 0:
             return False
 
-        expected_nonce = self.storage_engine.get_nonce_for_account(transaction.sender)
+        _, expected_nonce = self.storage_engine.get_nonce_for_account(transaction.sender)
         if transaction.nonce != expected_nonce:
             return False
 


### PR DESCRIPTION
Modify the `get_nonce_for_account` method in `src/tinychain.py` to return a tuple with balance and nonce.

* **Update `get_nonce_for_account` method:**
  - Change the method to return a tuple containing balance and nonce.
  - Adjust the return statement to return `(0, 0)` if account data is not found.

* **Update `set_nonce_for_account` method:**
  - Modify the method to set the nonce in a dictionary with keys "balance" and "nonce".

* **Update `validate_transaction` method in `src/validation_engine.py`:**
  - Adjust the method to handle the tuple returned by `get_nonce_for_account`.

