### PR TITLE
Modify broadcast functions to send messages without waiting for a response

### DIFF
--- a/src/peer_communication.py
+++ b/src/peer_communication.py
@@ -5,20 +5,17 @@ from block import BlockHeader, Signature
 from wallet import Wallet
 from parameters import PEER_URIS
 
-async def broadcast_block_header(block_header):
+def broadcast_block_header(block_header):
     for peer_uri in PEER_URIS:
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.post(f'http://{peer_uri}/receive_block', json={'block_header': block_header.to_dict()}) as response:
-                    if response.status == 200:
-                        logging.info(f"Block header broadcasted to peer {peer_uri}")
-                    else:
-                        logging.error(f"Failed to broadcast block header to peer {peer_uri}")
+                session.post(f'http://{peer_uri}/receive_block', json={'block_header': block_header.to_dict()})
+            logging.info(f"Block header broadcasted to peer {peer_uri}")
         except Exception as e:
             logging.error(f"Error broadcasting block header to peer {peer_uri}: {e}")
 
-async def receive_block_header(request):
-    data = await request.json()
+def receive_block_header(request):
+    data = request.json()
     block_header_data = data.get('block_header')
     if not block_header_data:
         return web.json_response({'error': 'Invalid block header data'}, status=400)
@@ -44,15 +41,12 @@ async def receive_block_header(request):
 
     return web.json_response({'message': 'Block header received and processed'})
 
-async def broadcast_transaction(transaction, sender_uri):
+def broadcast_transaction(transaction, sender_uri):
     for peer_uri in PEER_URIS:
         if peer_uri != sender_uri:
             try:
                 async with aiohttp.ClientSession() as session:
-                    async with session.post(f'http://{peer_uri}/send_transaction', json={'transaction': transaction.to_dict()}) as response:
-                        if response.status == 200:
-                            logging.info(f"Transaction broadcasted to peer {peer_uri}")
-                        else:
-                            logging.error(f"Failed to broadcast transaction to peer {peer_uri}")
+                    session.post(f'http://{peer_uri}/send_transaction', json={'transaction': transaction.to_dict()})
+                logging.info(f"Transaction broadcasted to peer {peer_uri}")
             except Exception as e:
                 logging.error(f"Error broadcasting transaction to peer {peer_uri}: {e}")


### PR DESCRIPTION
Modify `broadcast_block_header` and `broadcast_transaction` functions to send messages without waiting for a response and log the broadcast attempt.

* Update `broadcast_block_header` to remove async and send messages without waiting for a response.
* Log the broadcast attempt in `broadcast_block_header`.
* Update `receive_block_header` to remove async and follow the style of `broadcast_block_header`.
* Update `broadcast_transaction` to remove async and send messages without waiting for a response.
* Log the broadcast attempt in `broadcast_transaction`.

