### PR TITLE
Modify broadcast functions to send messages without waiting for a response

### DIFF
--- a/src/peer_communication.py
+++ b/src/peer_communication.py
@@ -9,11 +9,8 @@ async def broadcast_block_header(block_header):
     for peer_uri in PEER_URIS:
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.post(f'http://{peer_uri}/receive_block', json={'block_header': block_header.to_dict()}) as response:
-                    if response.status == 200:
-                        logging.info(f"Block header broadcasted to peer {peer_uri}")
-                    else:
-                        logging.error(f"Failed to broadcast block header to peer {peer_uri}")
+                session.post(f'http://{peer_uri}/receive_block', json={'block_header': block_header.to_dict()})
+                logging.info(f"Block header broadcast attempt to peer {peer_uri}")
         except Exception as e:
             logging.error(f"Error broadcasting block header to peer {peer_uri}: {e}")
 
@@ -49,10 +46,7 @@ async def broadcast_transaction(transaction, sender_uri):
         if peer_uri != sender_uri:
             try:
                 async with aiohttp.ClientSession() as session:
-                    async with session.post(f'http://{peer_uri}/send_transaction', json={'transaction': transaction.to_dict()}) as response:
-                        if response.status == 200:
-                            logging.info(f"Transaction broadcasted to peer {peer_uri}")
-                        else:
-                            logging.error(f"Failed to broadcast transaction to peer {peer_uri}")
+                    session.post(f'http://{peer_uri}/send_transaction', json={'transaction': transaction.to_dict()})
+                    logging.info(f"Transaction broadcast attempt to peer {peer_uri}")
             except Exception as e:
                 logging.error(f"Error broadcasting transaction to peer {peer_uri}: {e}")


### PR DESCRIPTION
Modify `broadcast_block_header` and `broadcast_transaction` functions to send messages without waiting for a response and log the broadcast attempt.

* Update `broadcast_block_header` to send messages without waiting for a response and log the broadcast attempt.
* Update `broadcast_transaction` to send messages without waiting for a response and log the broadcast attempt.

