### PR TITLE
Add chain id to block structure

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,7 @@ The `signatures` field in the `BlockHeader` is an array of `Signature` objects. 
 - **Timestamp**: The timestamp of the signature.
 - **SignatureData**: The actual signature data.
 - **ValidatorIndex**: The index of the validator.
+- **ChainID**: The ID of the blockchain.
 
 ## High-Level Diagram
 

--- a/src/block.py
+++ b/src/block.py
@@ -10,6 +10,7 @@ block_header_schema = {
         'merkle_root': {'type': 'string'},
         'state_root': {'type': 'string'},
         'proposer': {'type': 'string'},
+        'chain_id': {'type': 'string'},
         'signatures': {
             'type': 'array',
             'items': {
@@ -25,7 +26,7 @@ block_header_schema = {
         },
         'transaction_hashes': {'type': 'array', 'items': {'type': 'string'}}
     },
-    'required': ['block_hash', 'height', 'timestamp', 'previous_block_hash', 'state_root', 'proposer', 'signatures', 'transaction_hashes']
+    'required': ['block_hash', 'height', 'timestamp', 'previous_block_hash', 'state_root', 'proposer', 'chain_id', 'signatures', 'transaction_hashes']
 }
 
 class Signature:
@@ -55,7 +56,7 @@ class Signature:
         }
 
 class BlockHeader:
-    def __init__(self, block_hash, height, timestamp, previous_block_hash, merkle_root, state_root, proposer, signatures, transaction_hashes):
+    def __init__(self, block_hash, height, timestamp, previous_block_hash, merkle_root, state_root, proposer, chain_id, signatures, transaction_hashes):
         self.block_hash = block_hash
         self.height = height
         self.timestamp = timestamp
@@ -63,6 +64,7 @@ class BlockHeader:
         self.merkle_root = merkle_root
         self.state_root = state_root
         self.proposer = proposer
+        self.chain_id = chain_id
         self.signatures = [Signature.from_dict(sig) for sig in signatures]
         self.transaction_hashes = transaction_hashes
 
@@ -76,6 +78,7 @@ class BlockHeader:
             header_data['merkle_root'],
             header_data['state_root'],
             header_data['proposer'],
+            header_data['chain_id'],
             header_data['signatures'],
             header_data['transaction_hashes']
         )
@@ -90,6 +93,7 @@ class BlockHeader:
             'merkle_root': self.merkle_root,
             'state_root': self.state_root,
             'proposer': self.proposer,
+            'chain_id': self.chain_id,
             'signatures': [sig.to_dict() for sig in self.signatures],
             'transaction_hashes': self.transaction_hashes
         }

--- a/src/tinychain.py
+++ b/src/tinychain.py
@@ -57,8 +57,8 @@ class Forger:
         self.current_proposer_index = 0  # Initialize the current proposer index
 
     @staticmethod
-    def generate_block_hash(merkle_root, timestamp, state_root, previous_block_hash):
-        values = [merkle_root, str(timestamp), str(state_root), previous_block_hash]
+    def generate_block_hash(merkle_root, timestamp, state_root, previous_block_hash, chain_id):
+        values = [merkle_root, str(timestamp), str(state_root), previous_block_hash, chain_id]
         concatenated_string = f"{''.join(values)}".encode()
         return blake3.blake3(concatenated_string).hexdigest()
 
@@ -149,7 +149,8 @@ class Forger:
                 state_root, new_state = tvm_engine.exec(valid_transactions_to_forge, self.proposer)
                 transaction_hashes = [t.to_dict()['transaction_hash'] for t in valid_transactions_to_forge]
                 merkle_root = self.compute_merkle_root(transaction_hashes)
-                block_hash = self.generate_block_hash(merkle_root, timestamp, state_root, previous_block_hash)
+                chain_id = "tinychain"  # Example chain_id
+                block_hash = self.generate_block_hash(merkle_root, timestamp, state_root, previous_block_hash, chain_id)
                 signature = self.sign(block_hash)
                 validator_index = self.get_validator_index(self.proposer)
                 signatures = [Signature(self.proposer, timestamp, signature, validator_index)]
@@ -161,7 +162,8 @@ class Forger:
                 transaction_hashes = [t.to_dict()['transaction_hash'] for t in transactions_to_forge]
                 merkle_root = self.compute_merkle_root(transaction_hashes)
                 previous_block_hash = "00000000"
-                block_hash = self.generate_block_hash(merkle_root, timestamp, state_root, previous_block_hash)
+                chain_id = "tinychain"  # Example chain_id
+                block_hash = self.generate_block_hash(merkle_root, timestamp, state_root, previous_block_hash, chain_id)
                 signature = "genesis_signature"
                 validator_index = -1
                 signatures = [Signature(self.proposer, timestamp, signature, validator_index)]
@@ -174,6 +176,7 @@ class Forger:
                 merkle_root,
                 state_root,
                 self.proposer,
+                chain_id,
                 signatures,
                 transaction_hashes
             )
@@ -203,6 +206,7 @@ class Forger:
                         block_header.merkle_root,
                         block_header.state_root,
                         block_header.proposer,
+                        block_header.chain_id,
                         signatures,
                         block_header.transaction_hashes
                     )
@@ -374,6 +378,7 @@ class StorageEngine:
                 'state_root': block.header.state_root,
                 'previous_block_hash': block.header.previous_block_hash,
                 'proposer': block.header.proposer,
+                'chain_id': block.header.chain_id,
                 'signatures': [sig.to_dict() for sig in block.header.signatures],
                 'transactions': [transaction.to_dict() for transaction in block.transactions]
             }
@@ -394,6 +399,7 @@ class StorageEngine:
                 'state_root': block_header.state_root,
                 'previous_block_hash': block_header.previous_block_hash,
                 'proposer': block_header.proposer,
+                'chain_id': block_header.chain_id,
                 'signatures': [sig.to_dict() for sig in block_header.signatures],
                 'transaction_hashes': block_header.transaction_hashes
             }

--- a/src/validation_engine.py
+++ b/src/validation_engine.py
@@ -85,7 +85,7 @@ class ValidationEngine:
         if not (previous_block_header.timestamp < block.header.timestamp < current_time + time_tolerance):
             return False
 
-        values = [block.header.merkle_root, str(block.header.timestamp), str(block.header.state_root), previous_block_header.block_hash]
+        values = [block.header.merkle_root, str(block.header.timestamp), str(block.header.state_root), previous_block_header.block_hash, block.header.chain_id]
         concatenated_string = ''.join(values).encode()
         computed_hash = blake3(concatenated_string).hexdigest()
         if block.header.block_hash != computed_hash:


### PR DESCRIPTION
Implement the `chain_id` field to the block structure.

* **docs/architecture.md**
  - Add `chain_id` field to the block structure.
* **src/block.py**
  - Add `chain_id` field to `block_header_schema`.
  - Update `BlockHeader` class to include `chain_id` field.
  - Update `BlockHeader.from_dict` and `BlockHeader.to_dict` methods to handle `chain_id`.
* **src/tinychain.py**
  - Update `Forger.generate_block_hash` method to include `chain_id`.
  - Update `Forger.forge_new_block` method to set `chain_id` in `BlockHeader`.
  - Update `StorageEngine.store_block_header` method to store `chain_id`.
* **src/validation_engine.py**
  - Update `ValidationEngine.validate_block_header` method to validate `chain_id`.

