### PR TITLE
Add logging to trace block forging and broadcasting

### DIFF
--- a/src/peer_communication.py
+++ b/src/peer_communication.py
@@ -5,6 +5,7 @@ from wallet import Wallet
 from parameters import PEER_URIS
 
 def broadcast_block_header(block_header):
+    logging.info(f"Broadcasting block header with hash: {block_header.block_hash}")
     for peer_uri in PEER_URIS:
         try:
             response = requests.post(f'http://{peer_uri}/receive_block', json={'block_header': block_header.to_dict()}, timeout=0.3)
@@ -16,29 +17,35 @@ def broadcast_block_header(block_header):
             logging.error(f"Error broadcasting block header to peer {peer_uri}: {e}")
 
 def receive_block_header(request):
+    logging.info("Received block header")
     data = request.json()
     block_header_data = data.get('block_header')
     if not block_header_data:
+        logging.error("Invalid block header data received")
         return {'error': 'Invalid block header data'}, 400
 
     block_header = BlockHeader.from_dict(block_header_data)
 
     # Verify the validity of the block header
     if not validation_engine.validate_block_header(block_header, storage_engine.fetch_last_block_header()):
+        logging.error("Invalid block header received")
         return {'error': 'Invalid block header'}, 400
 
     # Verify the identity of the proposer through the included signature
     proposer_signature = find_proposer_signature(block_header)
     if proposer_signature is None or not Wallet.verify_signature(block_header.block_hash, proposer_signature.signature_data, proposer_signature.validator_address):
+        logging.error("Invalid proposer signature received")
         return {'error': 'Invalid proposer signature'}, 400
 
     # Check if a block header with the same hash already exists in memory
     if block_header.block_hash in forger.in_memory_block_headers:
         existing_block_header = forger.in_memory_block_headers[block_header.block_hash]
         existing_block_header.append_signatures(block_header.signatures)
+        logging.info(f"Appended signatures to existing block header with hash: {block_header.block_hash}")
     else:
         # Submit the received block header to the forger for replay
         forger.forge_new_block(replay=True, block_header=block_header)
+        logging.info(f"Submitted block header with hash: {block_header.block_hash} for replay")
 
     return {'message': 'Block header received and processed'}, 200
 

--- a/src/tinychain.py
+++ b/src/tinychain.py
@@ -103,7 +103,7 @@ class Forger:
         return True
 
     def forge_new_block(self, replay=True, block_header=None, is_genesis=False):
-
+        logging.info("Starting to forge a new block")
         transactions_to_forge = self.get_transactions_to_forge(replay, block_header)
 
         if not is_genesis:
@@ -224,6 +224,7 @@ class Forger:
         )
 
     def store_block(self, block, new_state):
+        logging.info("Storing block with hash: %s", block.header.block_hash)
         self.storage_engine.store_block(block)
         self.storage_engine.store_block_header(block.header)
         self.storage_engine.store_state(block.header.state_root, new_state)
@@ -239,25 +240,25 @@ class Forger:
 
     async def check_round_robin_result(self):
         while True:
-            print ("******************")
-            print ("ROUND RESULT CHECK")
-            print ("******************")
+            logging.info("******************")
+            logging.info("ROUND RESULT CHECK")
+            logging.info("******************")
             await asyncio.sleep(ROUND_TIMEOUT)
             previous_block_header = self.storage_engine.fetch_last_block_header()
             if previous_block_header:
-                print ("******************")
-                print ("previous_block_header is TRUE")
-                print ("******************")
+                logging.info("******************")
+                logging.info("previous_block_header is TRUE")
+                logging.info("******************")
                 current_time = int(time.time())
                 if current_time >= previous_block_header.timestamp + ROUND_TIMEOUT:
                     proposer = self.select_proposer()
-                    print ("******************")
-                    print ("PROPOSER RESULT: " + proposer)
-                    print ("******************")
+                    logging.info("******************")
+                    logging.info("PROPOSER RESULT: " + proposer)
+                    logging.info("******************")
                     if proposer == self.wallet.get_address():
-                        print ("******************")
-                        print ("forge_new_block")
-                        print ("******************")
+                        logging.info("******************")
+                        logging.info("forge_new_block")
+                        logging.info("******************")
                         self.forge_new_block(replay=False)
                     else:
                         await self.wait_for_new_block_headers()


### PR DESCRIPTION
Add logging statements to trace various processes in `tinychain.py` and `peer_communication.py`.

* **tinychain.py**
  - Add logging statements to `check_round_robin_result` to trace the round result check process.
  - Add logging statements to `forge_new_block` to trace the block forging process.
  - Add logging statements to `store_block` to trace the block storage process.

* **peer_communication.py**
  - Add logging statements to `broadcast_block_header` to trace the block header broadcasting process.
  - Add logging statements to `receive_block_header` to trace the block header receiving process.

