### PR TITLE
Ensure the genesis block is committed at its set timestamp

### DIFF
--- a/src/genesis.json
+++ b/src/genesis.json
@@ -9,5 +9,4 @@
     ],
     "staking_contract_address": "7374616b696e67",
     "genesis_timestamp": 1731369600
-  }
-  
+}

--- a/src/tinychain.py
+++ b/src/tinychain.py
@@ -195,6 +195,16 @@ class Forger:
         staking_contract_address = genesis_data['staking_contract_address']
         genesis_timestamp = genesis_data['genesis_timestamp']
 
+        current_time = int(time.time())
+        if current_time > genesis_timestamp + 3:
+            logging.error("Node has missed the network launch")
+            exit(1)
+        elif current_time < genesis_timestamp - 3:
+            while current_time < genesis_timestamp - 3:
+                logging.info("Waiting for the genesis timestamp...")
+                time.sleep(2)
+                current_time = int(time.time())
+
         genesis_transactions = [
             Transaction("genesis", genesis_addresses[0], 10000*TINYCOIN, 120, 0, "consensus", ""),
             Transaction(genesis_addresses[0], staking_contract_address, 1000*TINYCOIN, 110, 0, "genesis_signature_0", "stake"),


### PR DESCRIPTION
Modify `commit_genesis_block` method in `src/tinychain.py` to check the current time against the `genesis_timestamp` from `genesis.json`.

* Add logic to exit and print a message if the `genesis_timestamp` is 3 seconds higher than the current time.
* Add logic to wait and recheck every 2 seconds if the `genesis_timestamp` is more than 3 seconds lower than the current time.

Update `genesis_timestamp` in `src/genesis.json` to a future timestamp for testing purposes.

