### PR TITLE
Add integrity check parameter to block header broadcast

### DIFF
--- a/src/peer_communication.py
+++ b/src/peer_communication.py
@@ -54,7 +54,7 @@ def get_peers():
         logging.error(f"Unknown peer discovery method: {PEER_DISCOVERY_METHOD}")
         return []
 
-def broadcast_block_header(block_header):
+def broadcast_block_header(block_header, integrity_check):
     logging.info(f"Broadcasting block header with hash: {block_header.block_hash}")
     peers = get_peers()
     local_ips = get_local_ips()
@@ -63,7 +63,7 @@ def broadcast_block_header(block_header):
         if peer_ip in local_ips:
             continue  # Skip broadcasting to self
         try:
-            response = requests.post(f'http://{peer_uri}/receive_block', json={'block_header': block_header.to_dict()}, timeout=2)
+            response = requests.post(f'http://{peer_uri}/receive_block', json={'block_header': block_header.to_dict(), 'integrity_check': integrity_check}, timeout=2)
             if response.status_code == 200:
                 logging.info(f"Block header broadcasted to peer {peer_uri}")
             else:


### PR DESCRIPTION
Add integrity check parameter to block header broadcast and validation.

* **peer_communication.py**
  - Add `integrity_check` parameter to `broadcast_block_header` function.
  - Update `broadcast_block_header` function to include `integrity_check` in the JSON payload.

* **tinychain.py**
  - Add `generate_integrity_check` function to generate the integrity check parameter for the block header.
  - Update `forge_new_block` and `replay_block` functions to include the integrity check parameter in the `broadcast_block_header` call.
  - Update `receive_block_header` function to validate the integrity check parameter in the received message.

